### PR TITLE
Update course-manager-schema-setup.roo

### DIFF
--- a/roo-scripts/course-manager-schema-setup.roo
+++ b/roo-scripts/course-manager-schema-setup.roo
@@ -22,7 +22,7 @@ focus --class ~.model.Course
 field reference --fieldName trainingProgram --type ~.model.TrainingProgram --cardinality MANY_TO_ONE
 
 entity jpa --class ~.model.Tag --testAutomatically
-field string --fieldName tag --sizeMin 1 --sizeMax 25 --notNull
+field string --fieldName tagName --sizeMin 1 --sizeMax 25 --notNull
 field string --fieldName description --sizeMax 250 --notNull
 field set --fieldName courses --type ~.model.Course --cardinality MANY_TO_MANY
 


### PR DESCRIPTION
Having a field "tag" in an entity "Tag" causes a generation of an input field with id
"c_org_rooinaction_coursemanager_model_Tag_tag" in the create.jspx page.

```
<form:create id="fc_org_rooinaction_coursemanager_model_Tag" modelAttribute="tag" path="/tags" render="${empty dependencies}" z="5lywplbe5H/qB3L4d4NDJavhl9I=">
...
<field:input field="name" id="c_org_rooinaction_coursemanager_model_Tag_tag" max="25" min="1" required="true" z="mzy1IkMjLBzazsVeN3p4T8bcfQ4="/>
...
</form:create>
```

This in turn causes:

```
TRACE org.springframework.beans.TypeConverterDelegate - Field [<any tag here>] isn't an enum value
java.lang.NoSuchFieldException: <any tag  here>
    at java.lang.Class.getField(Class.java:1522)
    at org.springframework.beans.TypeConverterDelegate.attemptToConvertStringToEnum(TypeConverterDelegate.java:316)
    at org.springframework.beans.TypeConverterDelegate.convertIfNecessary(TypeConverterDelegate.java:243)
    at org.springframework.beans.TypeConverterDelegate.convertIfNecessary(TypeConverterDelegate.java:93)
```

This is rather a roo 1.2.5.RELEASE [rev 8341dc2] bug, nevertheless it's can save some beginner's time.
